### PR TITLE
feat: Update SDK to 9.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 9.1.1
+### Bug Fixes
+- Fixed virtual visit crash when integrating the SDK using Service Package Manager (SPM).
+- Fixed issue where canceling a virtual visit was taking multiple seconds before dismissing the waiting room screen.
+- Fixed issue where localization strings were not available when integrating the SDK using CocoaPods.
+- Added server logs to track the "Index out of range" error in ChatViewController.messageForItem(IndexPath, MessagesCollectionView).
+
 ## 9.1.0
 ### New
 This version of the SDK adds support for virtual visit transfers between providers. To accomplish this we've added a number of things:

--- a/DexcareSDK.podspec
+++ b/DexcareSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'DexcareSDK'
-  s.version      = '9.1.0'
+  s.version      = '9.1.1'
   s.platform = :ios, '13.0'
   s.swift_version = '5.0'
   s.summary      = 'DexcareSDK library for express care services'
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/DexcareiOSSDK/**/*.swift'
   s.resource_bundles = {
-    'DexcareSDK' => ['Sources/DexcareiOSSDK/**/*.{xib,storyboard,xcassets}']
+    'DexcareSDK' => ['Sources/DexcareiOSSDK/**/*.{xib,storyboard,xcassets,strings}']
   }
 
   # DexcareSDK dependency

--- a/Sources/DexcareiOSSDK/Common/Bundle+DexcareSDK.swift
+++ b/Sources/DexcareiOSSDK/Common/Bundle+DexcareSDK.swift
@@ -4,7 +4,14 @@ import Foundation
 
 extension Bundle {
     static var dexcareSDK: Bundle {
+        // SPM and cocoapods do not share package ressources (images, storyboards, etc.) the same way.
+        #if SWIFT_PACKAGE
+        // SPM
+        let currentBundle = Bundle.module
+        #else
+        // Cocoapods
         let currentBundle = Bundle(for: DexcareSDK.self)
+        #endif
         
         // Because OpenTok is a static framework,
         // We may need to expose Dexcare as a static framework/resource bundle for development

--- a/Sources/DexcareiOSSDK/Info.plist
+++ b/Sources/DexcareiOSSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>9.1.0</string>
+	<string>9.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSCameraUsageDescription</key>

--- a/Sources/DexcareiOSSDK/VirtualVisit/ChatViewController.swift
+++ b/Sources/DexcareiOSSDK/VirtualVisit/ChatViewController.swift
@@ -21,6 +21,7 @@ protocol ChatView: AnyObject {
 
 class ChatViewController: MessagesViewController, ChatView {
     weak var manager: VirtualVisitManagerType?
+    private var serverLogger: LoggingService?
     lazy var linkHandler: ExternalLinkHandler = UIApplication.shared
     
     // Add a small (but not too big) delay on when to refresh the collection view or typing state
@@ -40,8 +41,10 @@ class ChatViewController: MessagesViewController, ChatView {
     var messages: [ChatMessage] = []
     let semaphore = DispatchSemaphore(value: 1)
     
-    init(manager: VirtualVisitManagerType) {
+    init(manager: VirtualVisitManagerType,
+         serverLogger: LoggingService?) {
         self.manager = manager
+        self.serverLogger = serverLogger
         userSender = ChatSender(id: manager.userId, displayName: manager.chatDisplayName)
         super.init(nibName: nil, bundle: nil)
     }
@@ -222,6 +225,15 @@ extension ChatViewController: MessagesDataSource {
     }
     
     func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+        /// There is an issue where the message does not exist at the given index.
+        /// Unfortunetly, we are unable to reproduce the issue.
+        /// We added extra logs to track the issue and help us reproduce it.
+        ///
+        /// Internal Issue: ENG-11367
+        if let message = messages[safe: indexPath.section] {
+            return message
+        }
+        serverLogger?.postMessage(message: "ChatViewController::messageForItem(at \(indexPath.section)) does not exist. Total number of sections = \(messages.count).")
         return messages[indexPath.section]
     }
     

--- a/Sources/DexcareiOSSDK/VirtualVisit/DexcareVirtualVisit.storyboard
+++ b/Sources/DexcareiOSSDK/VirtualVisit/DexcareVirtualVisit.storyboard
@@ -13,7 +13,7 @@
         <!--Waiting Room View Controller-->
         <scene sceneID="o4H-C5-ntY">
             <objects>
-                <viewController storyboardIdentifier="WaitingRoomViewController" id="GIL-eq-BzS" customClass="WaitingRoomViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="WaitingRoomViewController" id="GIL-eq-BzS" customClass="WaitingRoomViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ldn-Db-Gqf">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -134,7 +134,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X2w-2G-2vK">
                                                 <rect key="frame" x="0.0" y="599" width="390" height="163"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6g-M2-5Ha" customClass="TytoCareButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                                    <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f6g-M2-5Ha" customClass="TytoCareButton" customModule="DexcareiOSSDK">
                                                         <rect key="frame" x="226" y="20" width="144" height="54"/>
                                                         <color key="backgroundColor" name="tytoCarePurple"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="QUESTION_BUTTON" label="Chat with our providers"/>
@@ -167,7 +167,7 @@
                                                             <action selector="chatButtonTapped" destination="GIL-eq-BzS" eventType="touchUpInside" id="qF1-E0-3FU"/>
                                                         </connections>
                                                     </button>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qzs-2w-V7U" userLabel="Self Video Preview View" customClass="PreviewView" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qzs-2w-V7U" userLabel="Self Video Preview View" customClass="PreviewView" customModule="DexcareiOSSDK">
                                                         <rect key="frame" x="20" y="25" width="85" height="118"/>
                                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="SELF_VIDEO_VIEW" label="Your Video Preview">
@@ -340,7 +340,7 @@
         <!--Visit View Controller-->
         <scene sceneID="HGl-Yl-Qye">
             <objects>
-                <viewController storyboardIdentifier="VisitViewController" id="bkY-Bk-jEC" customClass="VisitViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="VisitViewController" id="bkY-Bk-jEC" customClass="VisitViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="FeP-YF-R2K">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -390,7 +390,7 @@
                                     <action selector="localViewButtonTapped:" destination="bkY-Bk-jEC" eventType="touchUpInside" id="rJN-gp-CsH"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xCd-Zq-Uds" customClass="TytoCareButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xCd-Zq-Uds" customClass="TytoCareButton" customModule="DexcareiOSSDK">
                                 <rect key="frame" x="226" y="675" width="144" height="54"/>
                                 <color key="backgroundColor" name="tytoCarePurple"/>
                                 <accessibility key="accessibilityConfiguration" identifier="QUESTION_BUTTON" label="Chat with our providers"/>

--- a/Sources/DexcareiOSSDK/VirtualVisit/Tytocare/TytoCare.storyboard
+++ b/Sources/DexcareiOSSDK/VirtualVisit/Tytocare/TytoCare.storyboard
@@ -13,7 +13,7 @@
         <!--TytoCareSetup-->
         <scene sceneID="GfL-YD-Fif">
             <objects>
-                <viewController storyboardIdentifier="TytoCareSetupViewController" title="TytoCareSetup" id="F4k-f1-Afq" customClass="TytoCareSetupViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TytoCareSetupViewController" title="TytoCareSetup" id="F4k-f1-Afq" customClass="TytoCareSetupViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HNg-77-cvX">
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -116,7 +116,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gxj-5w-2YW">
                                 <rect key="frame" x="0.0" y="757" width="428" height="75"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dVj-ig-jts" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dVj-ig-jts" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK">
                                         <rect key="frame" x="94" y="17.666666666666629" width="240" height="40"/>
                                         <color key="backgroundColor" name="tytoCareButtonBlue"/>
                                         <constraints>
@@ -205,7 +205,7 @@
         <!--TytoCarePrivacy-->
         <scene sceneID="CG2-zU-B53">
             <objects>
-                <viewController storyboardIdentifier="TytoCareMissingPrivacyViewController" title="TytoCareSetup" id="FyZ-xh-P8p" userLabel="TytoCarePrivacy" customClass="TytoCareMissingPrivacyViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TytoCareMissingPrivacyViewController" title="TytoCareSetup" id="FyZ-xh-P8p" userLabel="TytoCarePrivacy" customClass="TytoCareMissingPrivacyViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Qaj-6F-ghD">
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -258,7 +258,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yrb-oj-E7O">
                                 <rect key="frame" x="0.0" y="757" width="428" height="75"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WOy-Sv-bta" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WOy-Sv-bta" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK">
                                         <rect key="frame" x="94" y="17.666666666666629" width="240" height="40"/>
                                         <color key="backgroundColor" name="tytoCareButtonBlue"/>
                                         <constraints>
@@ -342,7 +342,7 @@
         <!--Tyto Care Wifi Name View Controller-->
         <scene sceneID="E7V-Nh-7eG">
             <objects>
-                <viewController storyboardIdentifier="TytoCareWifiNameViewController" id="Lcv-pu-2Fv" customClass="TytoCareWifiNameViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TytoCareWifiNameViewController" id="Lcv-pu-2Fv" customClass="TytoCareWifiNameViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1xW-MX-BAq">
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -368,7 +368,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bXu-8b-cuo" customClass="SkyFloatingLabelTextField" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bXu-8b-cuo" customClass="SkyFloatingLabelTextField" customModule="DexcareiOSSDK">
                                                         <rect key="frame" x="0.0" y="73.333333333333329" width="378" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" id="avp-te-TZK"/>
@@ -454,7 +454,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Y1v-kb-h1b">
                                 <rect key="frame" x="0.0" y="757" width="428" height="75"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0cL-fd-xzM" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0cL-fd-xzM" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK">
                                         <rect key="frame" x="94" y="17.666666666666629" width="240" height="40"/>
                                         <color key="backgroundColor" name="tytoCareButtonBlue"/>
                                         <constraints>
@@ -541,7 +541,7 @@
         <!--Tyto Care Wifi Password View Controller-->
         <scene sceneID="zir-Jn-ZlP">
             <objects>
-                <viewController storyboardIdentifier="TytoCareWifiPasswordViewController" id="Enc-w8-e5o" customClass="TytoCareWifiPasswordViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TytoCareWifiPasswordViewController" id="Enc-w8-e5o" customClass="TytoCareWifiPasswordViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="GKY-9J-HJh">
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -567,7 +567,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iof-ti-6wK" customClass="SkyFloatingLabelTextField" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="iof-ti-6wK" customClass="SkyFloatingLabelTextField" customModule="DexcareiOSSDK">
                                                         <rect key="frame" x="0.0" y="73.333333333333329" width="378" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" id="M94-wg-iRg"/>
@@ -653,7 +653,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cYS-gS-ZeH">
                                 <rect key="frame" x="25" y="757" width="378" height="75"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="orQ-rd-M1E" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="orQ-rd-M1E" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK">
                                         <rect key="frame" x="69" y="17.666666666666629" width="240" height="40"/>
                                         <color key="backgroundColor" name="tytoCareButtonBlue"/>
                                         <constraints>
@@ -738,7 +738,7 @@
         <!--Tyto CareQR Code View Controller-->
         <scene sceneID="V47-h4-gyn">
             <objects>
-                <viewController storyboardIdentifier="TytoCareQRCodeViewController" id="1b6-iZ-Qtn" customClass="TytoCareQRCodeViewController" customModule="DexcareiOSSDK" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="TytoCareQRCodeViewController" id="1b6-iZ-Qtn" customClass="TytoCareQRCodeViewController" customModule="DexcareiOSSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Mqh-Pt-x7N">
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -799,7 +799,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="luF-i4-INy">
                                 <rect key="frame" x="25" y="787" width="378" height="55"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XdP-fw-VnE" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XdP-fw-VnE" customClass="TytoCareStyleButton" customModule="DexcareiOSSDK">
                                         <rect key="frame" x="69" y="7.6666666666666288" width="240" height="40"/>
                                         <color key="backgroundColor" name="tytoCareButtonBlue"/>
                                         <constraints>

--- a/Sources/DexcareiOSSDK/VirtualVisit/VirtualVisitNavigator.swift
+++ b/Sources/DexcareiOSSDK/VirtualVisit/VirtualVisitNavigator.swift
@@ -19,7 +19,7 @@ protocol VirtualVisitNavigatorType {
     func reconnected()
     func showVisit(completion: PresentingCompletion?) -> VisitView?
     func showWaitingRoom(completion: PresentingCompletion?) -> WaitingRoomView?
-    func showChat(manager: VirtualVisitManagerType) -> ChatView?
+    func showChat(manager: VirtualVisitManagerType, serverLogger: LoggingService?) -> ChatView?
     func displayAlert(title: String, message: String, actions: [AlertAction])
     func showHud()
     func hideHud()
@@ -125,7 +125,8 @@ class VirtualVisitNavigator: VirtualVisitNavigatorType {
         return waitingRoomViewController
     }
     
-    func showChat(manager: VirtualVisitManagerType) -> ChatView? {
+    func showChat(manager: VirtualVisitManagerType,
+                  serverLogger: LoggingService?) -> ChatView? {
         let existingNavigationController = presentedNavigationController()
         
         // Check to see if we have shown the chat already
@@ -134,7 +135,7 @@ class VirtualVisitNavigator: VirtualVisitNavigatorType {
             return existingNavigationController.viewControllers.last as? ChatViewController
         }
         
-        let chatViewController = ChatViewController(manager: manager)
+        let chatViewController = ChatViewController(manager: manager, serverLogger: serverLogger)
         existingNavigationController.pushViewController(chatViewController, animated: true)
         return chatViewController
     }


### PR DESCRIPTION
## 9.1.1
### Bug Fixes
- Fixed virtual visit crash when integrating the SDK using Service Package Manager (SPM).
- Fixed issue where canceling a virtual visit was taking multiple seconds before dismissing the waiting room screen.
- Fixed issue where localization strings were not available when integrating the SDK using CocoaPods.
- Added server logs to track the "Index out of range" error in ChatViewController.messageForItem(IndexPath, MessagesCollectionView).